### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/symfony" : ">=2.1,<=2.3"
+        "symfony/symfony" : ">=2.1,<3.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Backward compatibility will be kept in SF2 from 2.3 in series 2.x at all costs.
